### PR TITLE
fix spoofax tear down

### DIFF
--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/SpoofaxInit.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/SpoofaxInit.java
@@ -9,12 +9,6 @@ import org.metaborg.spt.core.SPTModule;
 import com.google.inject.Injector;
 
 public class SpoofaxInit {
-    private static class ShutdownHook extends Thread {
-        public void run() {
-            spoofaxMeta.close();
-            spoofax.close();
-        }
-    }
 
     private static Spoofax spoofax;
     private static SpoofaxMeta spoofaxMeta;
@@ -40,11 +34,19 @@ public class SpoofaxInit {
         return projectService;
     }
 
-
     public static boolean shouldInit() {
         return spoofax == null || spoofaxMeta == null;
     }
-
+    
+    public static void close() {
+        if(spoofaxMeta != null) {
+            spoofaxMeta.close();
+        }
+        if(spoofax != null) {
+            spoofax.close();
+        }
+    }
+    
     public static void init() throws MetaborgException {
         if(shouldInit()) {
             spoofax = new Spoofax(new MavenSpoofaxModule());
@@ -52,8 +54,6 @@ public class SpoofaxInit {
             sptInjector = spoofaxMeta.injector.createChildInjector(new SPTModule());
 
             projectService = spoofax.injector.getInstance(ISimpleProjectService.class);
-
-            Runtime.getRuntime().addShutdownHook(new ShutdownHook());
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/CleanMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/CleanMojo.java
@@ -23,42 +23,46 @@ public class CleanMojo extends AbstractSpoofaxLanguageMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip) {
-            return;
-        }
-        super.execute();
-        discoverLanguages();
-
-        final CleanInput input;
         try {
-            final CleanInputBuilder inputBuilder = new CleanInputBuilder(languageSpec());
-            // @formatter:off
-            input = inputBuilder
-                .withSelector(new SpoofaxIgnoresSelector())
-                .build(SpoofaxInit.spoofax().dependencyService)
-                ;
-            // @formatter:on
-        } catch(MetaborgException e) {
-            throw new MojoExecutionException("Building clean input failed unexpectedly", e);
-        }
-
-        try {
-            SpoofaxInit.spoofax().processorRunner.clean(input, null, null).schedule().block();
-            SpoofaxInit.spoofaxMeta().metaBuilder.clean(buildInput());
-        } catch(MetaborgException e) {
-            if(e.getCause() != null) {
-                logger.error("Exception thrown during clean", e);
-                logger.error("CLEAN FAILED");
-            } else {
-                final String message = e.getMessage();
-                if(message != null && !message.isEmpty()) {
-                    logger.error(message);
-                }
-                logger.error("CLEAN FAILED");
+            if(skip) {
+                return;
             }
-            throw new MojoFailureException("CLEAN FAILED", e);
-        } catch(InterruptedException e) {
-            // Ignore
+            super.execute();
+            discoverLanguages();
+    
+            final CleanInput input;
+            try {
+                final CleanInputBuilder inputBuilder = new CleanInputBuilder(languageSpec());
+                // @formatter:off
+                input = inputBuilder
+                    .withSelector(new SpoofaxIgnoresSelector())
+                    .build(SpoofaxInit.spoofax().dependencyService)
+                    ;
+                // @formatter:on
+            } catch(MetaborgException e) {
+                throw new MojoExecutionException("Building clean input failed unexpectedly", e);
+            }
+    
+            try {
+                SpoofaxInit.spoofax().processorRunner.clean(input, null, null).schedule().block();
+                SpoofaxInit.spoofaxMeta().metaBuilder.clean(buildInput());
+            } catch(MetaborgException e) {
+                if(e.getCause() != null) {
+                    logger.error("Exception thrown during clean", e);
+                    logger.error("CLEAN FAILED");
+                } else {
+                    final String message = e.getMessage();
+                    if(message != null && !message.isEmpty()) {
+                        logger.error(message);
+                    }
+                    logger.error("CLEAN FAILED");
+                }
+                throw new MojoFailureException("CLEAN FAILED", e);
+            } catch(InterruptedException e) {
+                // Ignore
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/CompileMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/CompileMojo.java
@@ -19,31 +19,35 @@ public class CompileMojo extends AbstractSpoofaxLanguageMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-        discoverLanguages();
-
-        final MavenProject project = mavenProject();
-        if(project == null) {
-            throw new MojoExecutionException("Maven project is null, cannot build project");
-        }
-
         try {
-            SpoofaxInit.spoofaxMeta().metaBuilder.compile(buildInput());
-        } catch(MetaborgException e) {
-            if(e.getCause() != null) {
-                logger.error("Exception thrown during build", e);
-                logger.error("BUILD FAILED");
-            } else {
-                final String message = e.getMessage();
-                if(message != null && !message.isEmpty()) {
-                    logger.error(message);
-                }
-                logger.error("BUILD FAILED");
+            if(skip || skipAll) {
+                return;
             }
-            throw new MojoFailureException("BUILD FAILED", e);
+            super.execute();
+            discoverLanguages();
+    
+            final MavenProject project = mavenProject();
+            if(project == null) {
+                throw new MojoExecutionException("Maven project is null, cannot build project");
+            }
+    
+            try {
+                SpoofaxInit.spoofaxMeta().metaBuilder.compile(buildInput());
+            } catch(MetaborgException e) {
+                if(e.getCause() != null) {
+                    logger.error("Exception thrown during build", e);
+                    logger.error("BUILD FAILED");
+                } else {
+                    final String message = e.getMessage();
+                    if(message != null && !message.isEmpty()) {
+                        logger.error(message);
+                    }
+                    logger.error("BUILD FAILED");
+                }
+                throw new MojoFailureException("BUILD FAILED", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/GenerateSourcesMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/GenerateSourcesMojo.java
@@ -24,50 +24,54 @@ public class GenerateSourcesMojo extends AbstractSpoofaxLanguageMojo {
     @Parameter(property = "spoofax.generate-sources.skip", defaultValue = "false") private boolean skip;
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-        discoverLanguages();
-
-        getLog().info("Generating Spoofax sources");
-
-        try {
-            SpoofaxInit.spoofaxMeta().metaBuilder.generateSources(buildInput(), null);
-        } catch(Exception e) {
-            throw new MojoFailureException(e.getMessage(), e);
-        }
-
-        try {
-            final BuildInputBuilder inputBuilder = new BuildInputBuilder(languageSpec());
-            // @formatter:off
-            final BuildInput input = inputBuilder
-                .withDefaultIncludePaths(true)
-                .withSourcesFromDefaultSourceLocations(true)
-                .withSelector(new SpoofaxIgnoresSelector())
-                .withMessagePrinter(new StreamMessagePrinter(SpoofaxInit.spoofax().sourceTextService, true, true, logger))
-                .withThrowOnErrors(true)
-                .withPardonedLanguageStrings(languageSpec().config().pardonedLanguages())
-                .addTransformGoal(new CompileGoal())
-                .build(SpoofaxInit.spoofax().dependencyService, SpoofaxInit.spoofax().languagePathService)
-                ;
-            // @formatter:on
-
-            SpoofaxInit.spoofax().processorRunner.build(input, null, null).schedule().block();
-        } catch(MetaborgException e) {
-            if(e.getCause() != null) {
-                logger.error("Exception thrown during generation", e);
-                logger.error("GENERATION FAILED");
-            } else {
-                final String message = e.getMessage();
-                if(message != null && !message.isEmpty()) {
-                    logger.error(message);
-                }
-                logger.error("GENERATION FAILED");
+            try {
+            if(skip || skipAll) {
+                return;
             }
-            throw new MojoFailureException("GENERATION FAILED", e);
-        } catch(InterruptedException e) {
-            // Ignore
+            super.execute();
+            discoverLanguages();
+    
+            getLog().info("Generating Spoofax sources");
+    
+            try {
+                SpoofaxInit.spoofaxMeta().metaBuilder.generateSources(buildInput(), null);
+            } catch(Exception e) {
+                throw new MojoFailureException(e.getMessage(), e);
+            }
+    
+            try {
+                final BuildInputBuilder inputBuilder = new BuildInputBuilder(languageSpec());
+                // @formatter:off
+                final BuildInput input = inputBuilder
+                    .withDefaultIncludePaths(true)
+                    .withSourcesFromDefaultSourceLocations(true)
+                    .withSelector(new SpoofaxIgnoresSelector())
+                    .withMessagePrinter(new StreamMessagePrinter(SpoofaxInit.spoofax().sourceTextService, true, true, logger))
+                    .withThrowOnErrors(true)
+                    .withPardonedLanguageStrings(languageSpec().config().pardonedLanguages())
+                    .addTransformGoal(new CompileGoal())
+                    .build(SpoofaxInit.spoofax().dependencyService, SpoofaxInit.spoofax().languagePathService)
+                    ;
+                // @formatter:on
+    
+                SpoofaxInit.spoofax().processorRunner.build(input, null, null).schedule().block();
+            } catch(MetaborgException e) {
+                if(e.getCause() != null) {
+                    logger.error("Exception thrown during generation", e);
+                    logger.error("GENERATION FAILED");
+                } else {
+                    final String message = e.getMessage();
+                    if(message != null && !message.isEmpty()) {
+                        logger.error(message);
+                    }
+                    logger.error("GENERATION FAILED");
+                }
+                throw new MojoFailureException("GENERATION FAILED", e);
+            } catch(InterruptedException e) {
+                // Ignore
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/InitializeMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/InitializeMojo.java
@@ -16,15 +16,19 @@ public class InitializeMojo extends AbstractSpoofaxLanguageMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-
         try {
-            SpoofaxInit.spoofaxMeta().metaBuilder.initialize(buildInput());
-        } catch(MetaborgException e) {
-            throw new MojoFailureException("Error initializing", e);
+            if(skip || skipAll) {
+                return;
+            }
+            super.execute();
+    
+            try {
+                SpoofaxInit.spoofaxMeta().metaBuilder.initialize(buildInput());
+            } catch(MetaborgException e) {
+                throw new MojoFailureException("Error initializing", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/PackageMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/PackageMojo.java
@@ -30,39 +30,43 @@ public class PackageMojo extends AbstractSpoofaxLanguageMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        super.execute();
-
-        final FileObject spxArchiveFile = paths().spxArchiveFile(languageSpec().config().identifier().toFileString());
-        final File localSpxArchiveFile = SpoofaxInit.spoofax().resourceService.localFile(spxArchiveFile);
-        mavenProject().getArtifact().setFile(localSpxArchiveFile);
-
-        if(skip || skipAll) {
-            return;
-        }
-
-        getLog().info("Packaging Spoofax language");
-
         try {
-            SpoofaxInit.spoofaxMeta().metaBuilder.pkg(buildInput());
-            SpoofaxInit.spoofaxMeta().metaBuilder.archive(buildInput());
-        } catch(Exception e) {
-            throw new MojoFailureException(e.getMessage(), e);
-        }
-
-        // Resolve to contents of the archive (zip) file, such that discovery looks inside the zip file.
-        final FileObject zipSpxArchiveFile =
-            SpoofaxInit.spoofax().resourceService.resolve("zip:" + spxArchiveFile.getName().getURI() + "!/");
-        getLog().info("Reloading language from: " + zipSpxArchiveFile);
-        try {
-            final Iterable<ILanguageDiscoveryRequest> request =
-                SpoofaxInit.spoofax().languageDiscoveryService.request(zipSpxArchiveFile);
-            final Iterable<ILanguageComponent> components =
-                SpoofaxInit.spoofax().languageDiscoveryService.discover(request);
-            if(Iterables.isEmpty(components)) {
-                throw new MojoExecutionException("Failed to reload language, no components were discovered");
+            super.execute();
+    
+            final FileObject spxArchiveFile = paths().spxArchiveFile(languageSpec().config().identifier().toFileString());
+            final File localSpxArchiveFile = SpoofaxInit.spoofax().resourceService.localFile(spxArchiveFile);
+            mavenProject().getArtifact().setFile(localSpxArchiveFile);
+    
+            if(skip || skipAll) {
+                return;
             }
-        } catch(MetaborgException e) {
-            throw new MojoExecutionException("Failed to reload language", e);
+    
+            getLog().info("Packaging Spoofax language");
+    
+            try {
+                SpoofaxInit.spoofaxMeta().metaBuilder.pkg(buildInput());
+                SpoofaxInit.spoofaxMeta().metaBuilder.archive(buildInput());
+            } catch(Exception e) {
+                throw new MojoFailureException(e.getMessage(), e);
+            }
+    
+            // Resolve to contents of the archive (zip) file, such that discovery looks inside the zip file.
+            final FileObject zipSpxArchiveFile =
+                SpoofaxInit.spoofax().resourceService.resolve("zip:" + spxArchiveFile.getName().getURI() + "!/");
+            getLog().info("Reloading language from: " + zipSpxArchiveFile);
+            try {
+                final Iterable<ILanguageDiscoveryRequest> request =
+                    SpoofaxInit.spoofax().languageDiscoveryService.request(zipSpxArchiveFile);
+                final Iterable<ILanguageComponent> components =
+                    SpoofaxInit.spoofax().languageDiscoveryService.discover(request);
+                if(Iterables.isEmpty(components)) {
+                    throw new MojoExecutionException("Failed to reload language, no components were discovered");
+                }
+            } catch(MetaborgException e) {
+                throw new MojoExecutionException("Failed to reload language", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/VerifyMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/VerifyMojo.java
@@ -27,46 +27,50 @@ public class VerifyMojo extends AbstractSpoofaxLanguageMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-
         try {
-            final FileObject[] sptFiles = basedirLocation().findFiles(FileSelectorUtils.extension("spt"));
-            if(sptFiles == null || sptFiles.length == 0) {
-                // Skip silently
+            if(skip || skipAll) {
                 return;
             }
-        } catch(FileSystemException e) {
-            throw new MojoExecutionException("Error determining files to test", e);
-        }
-
-        final Iterable<? extends ILanguageImpl> sptLangs =
-            SpoofaxInit.spoofax().languageService.getAllImpls("org.metaborg", "org.metaborg.meta.lang.spt");
-        final int sptLangsSize = Iterables.size(sptLangs);
-        if(sptLangsSize == 0) {
-            logger.info(
-                "Skipping tests because SPT language implementation (org.metaborg:org.metaborg.meta.lang.spt) is not a dependency");
-            return;
-        }
-        if(sptLangsSize > 1) {
-            throw new MojoExecutionException("Multiple SPT language implementations were found");
-        }
-        final ILanguageImpl sptLang = Iterables.get(sptLangs, 0);
-
-        final ILanguageImpl testLang =
-            SpoofaxInit.spoofax().languageService.getImpl(languageSpec().config().identifier());
-        if(testLang == null) {
-            logger.info("Skipping tests because language under test was not found");
-            return;
-        }
-
-        try {
-            logger.info("Running SPT tests");
-            SpoofaxInit.sptInjector().getInstance(SPTRunner.class).test(languageSpec(), sptLang, testLang);
-        } catch(MetaborgException e) {
-            throw new MojoFailureException("Error testing", e);
+            super.execute();
+    
+            try {
+                final FileObject[] sptFiles = basedirLocation().findFiles(FileSelectorUtils.extension("spt"));
+                if(sptFiles == null || sptFiles.length == 0) {
+                    // Skip silently
+                    return;
+                }
+            } catch(FileSystemException e) {
+                throw new MojoExecutionException("Error determining files to test", e);
+            }
+    
+            final Iterable<? extends ILanguageImpl> sptLangs =
+                SpoofaxInit.spoofax().languageService.getAllImpls("org.metaborg", "org.metaborg.meta.lang.spt");
+            final int sptLangsSize = Iterables.size(sptLangs);
+            if(sptLangsSize == 0) {
+                logger.info(
+                    "Skipping tests because SPT language implementation (org.metaborg:org.metaborg.meta.lang.spt) is not a dependency");
+                return;
+            }
+            if(sptLangsSize > 1) {
+                throw new MojoExecutionException("Multiple SPT language implementations were found");
+            }
+            final ILanguageImpl sptLang = Iterables.get(sptLangs, 0);
+    
+            final ILanguageImpl testLang =
+                SpoofaxInit.spoofax().languageService.getImpl(languageSpec().config().identifier());
+            if(testLang == null) {
+                logger.info("Skipping tests because language under test was not found");
+                return;
+            }
+    
+            try {
+                logger.info("Running SPT tests");
+                SpoofaxInit.sptInjector().getInstance(SPTRunner.class).test(languageSpec(), sptLang, testLang);
+            } catch(MetaborgException e) {
+                throw new MojoFailureException("Error testing", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/GenerateEclipseProjectMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/GenerateEclipseProjectMojo.java
@@ -31,22 +31,26 @@ public class GenerateEclipseProjectMojo extends AbstractSpoofaxMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        super.execute();
-
-        final FileObject baseDir = basedirLocation();
-        final MavenProject project = mavenProject();
-
         try {
-            if(project == null || project.getFile() == null) {
-                generateFromPrompt(baseDir);
-            } else if("spoofax-language".equals(project.getPackaging())) {
-                generateFromProject(project);
-            } else {
-                getLog().error("Found existing project " + project.getName()
-                    + ", but it is not of packaging type 'spoofax-language'");
+            super.execute();
+    
+            final FileObject baseDir = basedirLocation();
+            final MavenProject project = mavenProject();
+    
+            try {
+                if(project == null || project.getFile() == null) {
+                    generateFromPrompt(baseDir);
+                } else if("spoofax-language".equals(project.getPackaging())) {
+                    generateFromProject(project);
+                } else {
+                    getLog().error("Found existing project " + project.getName()
+                        + ", but it is not of packaging type 'spoofax-language'");
+                }
+            } catch(FileSystemException e) {
+                throw new MojoExecutionException("Generating project failed unexpectedly", e);
             }
-        } catch(FileSystemException e) {
-            throw new MojoExecutionException("Generating project failed unexpectedly", e);
+        } finally {
+            SpoofaxInit.close();
         }
     }
 

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/GenerateProjectMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/GenerateProjectMojo.java
@@ -40,39 +40,43 @@ public class GenerateProjectMojo extends AbstractSpoofaxMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        super.execute();
-
-        final MavenProject project = mavenProject();
-
-        if(project != null && project.getFile() != null) {
-            final String message = logger.format("Found existing project {}, not continuing", project.getName());
-            throw new MojoFailureException(message);
-        }
-
-        // @formatter:off
-        final LangSpecGeneratorSettingsBuilder settingsBuilder = new LangSpecGeneratorSettingsBuilder()
-            .withGroupId(groupId)
-            .withId(id)
-            .withVersion((version != null && LanguageVersion.valid(version)) ? LanguageVersion.parse(version) : null)
-            .withName(name)
-            .withMetaborgVersion(metaborgVersion)
-            .withExtensions(extensions)
-            .withSyntaxType(syntaxType)
-            .withAnalysisType(analysisType)
-            ;
-        // @formatter:on
-
-        if(!settingsBuilder.isComplete()) {
-            Prompter prompter;
-            try {
-                prompter = Prompter.get();
-            } catch(IOException e) {
-                throw new MojoFailureException("Must run interactively", e);
+        try {
+            super.execute();
+    
+            final MavenProject project = mavenProject();
+    
+            if(project != null && project.getFile() != null) {
+                final String message = logger.format("Found existing project {}, not continuing", project.getName());
+                throw new MojoFailureException(message);
             }
-            settingsBuilder.configureFromPrompt(prompter);
+    
+            // @formatter:off
+            final LangSpecGeneratorSettingsBuilder settingsBuilder = new LangSpecGeneratorSettingsBuilder()
+                .withGroupId(groupId)
+                .withId(id)
+                .withVersion((version != null && LanguageVersion.valid(version)) ? LanguageVersion.parse(version) : null)
+                .withName(name)
+                .withMetaborgVersion(metaborgVersion)
+                .withExtensions(extensions)
+                .withSyntaxType(syntaxType)
+                .withAnalysisType(analysisType)
+                ;
+            // @formatter:on
+    
+            if(!settingsBuilder.isComplete()) {
+                Prompter prompter;
+                try {
+                    prompter = Prompter.get();
+                } catch(IOException e) {
+                    throw new MojoFailureException("Must run interactively", e);
+                }
+                settingsBuilder.configureFromPrompt(prompter);
+            }
+    
+            generate(settingsBuilder);
+        } finally {
+            SpoofaxInit.close();
         }
-
-        generate(settingsBuilder);
     }
 
 

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/RunMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/language/manual/RunMojo.java
@@ -23,20 +23,24 @@ public class RunMojo extends AbstractSpoofaxMojo {
     }
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-
-        getLog().info("Invoking strategy " + name + " [" + StringUtils.join(getArgs(), ", ") + "]");
-
-        final HybridInterpreter runtime = SpoofaxInit.spoofax().strategoRuntimeService.genericRuntime();
-        final ITermFactory factory = runtime.getFactory();
-        final Context context = new Context(factory);
         try {
-            context.invokeStrategyCLI(name, name, getArgs());
-        } catch(StrategoException ex) {
-            throw new MojoFailureException(ex.getMessage(), ex);
+            if(skip || skipAll) {
+                return;
+            }
+            super.execute();
+    
+            getLog().info("Invoking strategy " + name + " [" + StringUtils.join(getArgs(), ", ") + "]");
+    
+            final HybridInterpreter runtime = SpoofaxInit.spoofax().strategoRuntimeService.genericRuntime();
+            final ITermFactory factory = runtime.getFactory();
+            final Context context = new Context(factory);
+            try {
+                context.invokeStrategyCLI(name, name, getArgs());
+            } catch(StrategoException ex) {
+                throw new MojoFailureException(ex.getMessage(), ex);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/project/ProjectCleanMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/project/ProjectCleanMojo.java
@@ -20,29 +20,33 @@ public class ProjectCleanMojo extends AbstractSpoofaxMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip) {
-            return;
-        }
-        super.execute();
-        discoverLanguages();
-
-        final CleanInput input;
         try {
-            final CleanInputBuilder inputBuilder = new CleanInputBuilder(project());
-            // @formatter:off
-            input = inputBuilder
-                .withSelector(new SpoofaxIgnoresSelector())
-                .build(SpoofaxInit.spoofax().dependencyService)
-                ;
-            // @formatter:on
-        } catch(MetaborgException e) {
-            throw new MojoExecutionException("Building clean input failed unexpectedly", e);
-        }
-
-        try {
-            SpoofaxInit.spoofax().processorRunner.clean(input, null, null).schedule().block();
-        } catch(InterruptedException e) {
-            // Ignore
+            if(skip) {
+                return;
+            }
+            super.execute();
+            discoverLanguages();
+    
+            final CleanInput input;
+            try {
+                final CleanInputBuilder inputBuilder = new CleanInputBuilder(project());
+                // @formatter:off
+                input = inputBuilder
+                    .withSelector(new SpoofaxIgnoresSelector())
+                    .build(SpoofaxInit.spoofax().dependencyService)
+                    ;
+                // @formatter:on
+            } catch(MetaborgException e) {
+                throw new MojoExecutionException("Building clean input failed unexpectedly", e);
+            }
+    
+            try {
+                SpoofaxInit.spoofax().processorRunner.clean(input, null, null).schedule().block();
+            } catch(InterruptedException e) {
+                // Ignore
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/project/ProjectGenerateSourcesMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/project/ProjectGenerateSourcesMojo.java
@@ -26,33 +26,37 @@ public class ProjectGenerateSourcesMojo extends AbstractSpoofaxMojo {
     @Parameter(property = "spoofax.generate-sources.skip", defaultValue = "false") private boolean skip;
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-        discoverLanguages();
-
-        getLog().info("Generating Spoofax sources");
-
         try {
-            final BuildInputBuilder inputBuilder = new BuildInputBuilder(project());
-            // @formatter:off
-            final BuildInput input = inputBuilder
-                .withDefaultIncludePaths(true)
-                .withSourcesFromDefaultSourceLocations(true)
-                .withSelector(new SpoofaxIgnoresSelector())
-                .withMessagePrinter(new StreamMessagePrinter(SpoofaxInit.spoofax().sourceTextService, true, true, logger))
-                .withThrowOnErrors(true)
-                .addTransformGoal(new CompileGoal())
-                .build(SpoofaxInit.spoofax().dependencyService, SpoofaxInit.spoofax().languagePathService)
-                ;
-            // @formatter:on
-
-            SpoofaxInit.spoofax().processorRunner.build(input, null, null).schedule().block();
-        } catch(MetaborgException | InterruptedException e) {
-            throw new MojoExecutionException("Generating sources failed unexpectedly", e);
-        } catch(MetaborgRuntimeException e) {
-            throw new MojoFailureException("Generating sources failed", e);
+            if(skip || skipAll) {
+                return;
+            }
+            super.execute();
+            discoverLanguages();
+    
+            getLog().info("Generating Spoofax sources");
+    
+            try {
+                final BuildInputBuilder inputBuilder = new BuildInputBuilder(project());
+                // @formatter:off
+                final BuildInput input = inputBuilder
+                    .withDefaultIncludePaths(true)
+                    .withSourcesFromDefaultSourceLocations(true)
+                    .withSelector(new SpoofaxIgnoresSelector())
+                    .withMessagePrinter(new StreamMessagePrinter(SpoofaxInit.spoofax().sourceTextService, true, true, logger))
+                    .withThrowOnErrors(true)
+                    .addTransformGoal(new CompileGoal())
+                    .build(SpoofaxInit.spoofax().dependencyService, SpoofaxInit.spoofax().languagePathService)
+                    ;
+                // @formatter:on
+    
+                SpoofaxInit.spoofax().processorRunner.build(input, null, null).schedule().block();
+            } catch(MetaborgException | InterruptedException e) {
+                throw new MojoExecutionException("Generating sources failed unexpectedly", e);
+            } catch(MetaborgRuntimeException e) {
+                throw new MojoFailureException("Generating sources failed", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }

--- a/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/test/TestMojo.java
+++ b/spoofax-maven-plugin/src/main/java/org/metaborg/spoofax/maven/plugin/mojo/test/TestMojo.java
@@ -30,49 +30,53 @@ public class TestMojo extends AbstractSpoofaxMojo {
 
 
     @Override public void execute() throws MojoFailureException, MojoExecutionException {
-        if(skip || skipAll) {
-            return;
-        }
-        super.execute();
-
         try {
-            final FileObject[] sptFiles = basedirLocation().findFiles(FileSelectorUtils.extension("spt"));
-            if(sptFiles == null || sptFiles.length == 0) {
-                // Skip silently
+            if(skip || skipAll) {
                 return;
             }
-        } catch(FileSystemException e) {
-            throw new MojoExecutionException("Error determining files to test", e);
-        }
-
-        discoverLanguages();
-        discoverSelf();
-
-        final Iterable<? extends ILanguageImpl> sptLangs =
-            SpoofaxInit.spoofax().languageService.getAllImpls("org.metaborg", "org.metaborg.meta.lang.spt");
-        final int sptLangsSize = Iterables.size(sptLangs);
-        if(sptLangsSize == 0) {
-            logger.info(
-                "Skipping tests because SPT language implementation (org.metaborg:org.metaborg.meta.lang.spt) is not a dependency");
-            return;
-        }
-        if(sptLangsSize > 1) {
-            throw new MojoExecutionException("Multiple SPT language implementations were found");
-        }
-        final ILanguageImpl sptLang = Iterables.get(sptLangs, 0);
-
-        final LanguageIdentifier id = LanguageIdentifier.parseFull(languageUnderTest);
-        final ILanguageImpl testLang = SpoofaxInit.spoofax().languageService.getImpl(id);
-        if(testLang == null) {
-            logger.info("Skipping tests because language under test was not found");
-            return;
-        }
-
-        try {
-            logger.info("Running SPT tests");
-            SpoofaxInit.sptInjector().getInstance(SPTRunner.class).test(project(), sptLang, testLang);
-        } catch(MetaborgException e) {
-            throw new MojoFailureException("Error testing", e);
+            super.execute();
+    
+            try {
+                final FileObject[] sptFiles = basedirLocation().findFiles(FileSelectorUtils.extension("spt"));
+                if(sptFiles == null || sptFiles.length == 0) {
+                    // Skip silently
+                    return;
+                }
+            } catch(FileSystemException e) {
+                throw new MojoExecutionException("Error determining files to test", e);
+            }
+    
+            discoverLanguages();
+            discoverSelf();
+    
+            final Iterable<? extends ILanguageImpl> sptLangs =
+                SpoofaxInit.spoofax().languageService.getAllImpls("org.metaborg", "org.metaborg.meta.lang.spt");
+            final int sptLangsSize = Iterables.size(sptLangs);
+            if(sptLangsSize == 0) {
+                logger.info(
+                    "Skipping tests because SPT language implementation (org.metaborg:org.metaborg.meta.lang.spt) is not a dependency");
+                return;
+            }
+            if(sptLangsSize > 1) {
+                throw new MojoExecutionException("Multiple SPT language implementations were found");
+            }
+            final ILanguageImpl sptLang = Iterables.get(sptLangs, 0);
+    
+            final LanguageIdentifier id = LanguageIdentifier.parseFull(languageUnderTest);
+            final ILanguageImpl testLang = SpoofaxInit.spoofax().languageService.getImpl(id);
+            if(testLang == null) {
+                logger.info("Skipping tests because language under test was not found");
+                return;
+            }
+    
+            try {
+                logger.info("Running SPT tests");
+                SpoofaxInit.sptInjector().getInstance(SPTRunner.class).test(project(), sptLang, testLang);
+            } catch(MetaborgException e) {
+                throw new MojoFailureException("Error testing", e);
+            }
+        } finally {
+            SpoofaxInit.close();
         }
     }
 }


### PR DESCRIPTION
Using the jvm runtime shutdown hook for spoofax tear down seems to be too late ending up in 

```
org.apache.commons.vfs2.FileSystemException: Could not delete "file:///C:/Users/xxxx/AppData/Local/Temp/vfs_cache4173458639863143199/tmp_38845_stratego-javastrat.jar".
        at org.apache.commons.vfs2.provider.AbstractFileObject.deleteSelf(AbstractFileObject.java:553)
        at org.apache.commons.vfs2.provider.AbstractFileObject.delete(AbstractFileObject.java:496)
        at org.apache.commons.vfs2.provider.AbstractFileObject.deleteAll(AbstractFileObject.java:516)
        at org.apache.commons.vfs2.impl.DefaultFileReplicator.deleteFile(DefaultFileReplicator.java:173)
        at org.apache.commons.vfs2.impl.DefaultFileReplicator.close(DefaultFileReplicator.java:111)
        at org.metaborg.core.resource.ResourceService.close(ResourceService.java:53)
        at org.metaborg.core.MetaBorg.close(MetaBorg.java:158)
        at org.metaborg.spoofax.maven.plugin.SpoofaxInit$ShutdownHook.run(SpoofaxInit.java:15)
Caused by: org.apache.commons.vfs2.FileSystemException: Could not delete "C:\Users\xxxxx\AppData\Local\Temp\vfs_cache4173458639863143199\tmp_38845_stratego-javastrat.jar".
        at org.apache.commons.vfs2.provider.local.LocalFile.doDelete(LocalFile.java:131)
        at org.apache.commons.vfs2.provider.AbstractFileObject.deleteSelf(AbstractFileObject.java:542)
        ... 7 more
```

exceptions all the time.